### PR TITLE
check if the program specified by the user is in $PATH 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ and after they are done they delete the cmdID.json of their parent
 # todo
 - manpage also
 - support commands with `&&` (just feed them into bash -c lol)
-- smart check for no commandID by checking executables in bash against args[0]
 - return actual exit code instead of just one
 - cleanup routine (do we even need that?)
+- implement `--after` mode
+- install script

--- a/flagUtils.go
+++ b/flagUtils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,26 @@ func printUsage() {
 	blue.Fprintf(flag.CommandLine.Output(), "In second terminal: dchn cmd1 apt upgrade \n\n")
 	flag.PrintDefaults()
 	magenta.Fprintf(flag.CommandLine.Output(), "\nman dchn for more details \n")
+	os.Exit(2)
+}
+
+// check if the program exists in path
+func checkIfInPath(name string) bool {
+	for _, path_dir := range strings.Split(os.Getenv("PATH"), ":") {
+		progs, err := ioutil.ReadDir(path_dir)
+
+		if err != nil {
+			color.Red("unable to read from path at %s", path_dir)
+		}
+
+		for _, prog := range progs {
+			if prog.Name() == name {
+				return true
+			}
+		}
+	}
+	return false
+
 }
 
 func handleFlags() {
@@ -39,16 +60,19 @@ func handleFlags() {
 
 	if len(flag.Args()) < 2 {
 		printUsage()
-		os.Exit(2)
 	}
 
 	if !(chain_mode == MODE_OR || chain_mode == MODE_AND || chain_mode == MODE_NOT) {
 		printUsage()
-		os.Exit(2)
 	}
 
 	cmdID = flag.Args()[0]
 	cmd = flag.Args()[1:]
+
+	if !checkIfInPath(cmd[0]) {
+		color.Red("Unable to find program:%s in path, are you sure you specified a cmdID?\n\n", color.GreenString(cmd[0]))
+		printUsage()
+	}
 
 	logger.Debugf("mode: " + chain_mode)
 	logger.Debugf("cmdID: " + cmdID)


### PR DESCRIPTION
## Why
since the flag parsing of this tool is very loose we have no way to actually know if the user didn't provide a commandID and just went ahead and pasted their cmd
this catches that and reports it.